### PR TITLE
Upgrade dependencies to resolve vulnerability warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const fs = require('fs');
 const readChunk = require('read-chunk');
 const imageType = require('image-type');
 const execFile = require('child_process').execFile;
-const cwebp = require('cwebp-bin');
 const program = require('commander');
 const chalk = require('chalk');
 var fileList = [];
@@ -53,11 +52,13 @@ if (program.files) {
 }
 
 console.log(chalk.yellow("Found " + fileList.length + " image file(s) !"));
-fileList.forEach(function (file) {
-    execFile(cwebp, [file, '-o', file.replace(queryExtName(file),".webp")], function (err) {
-        if (err) {
-            throw err;
-        }
-        console.log(chalk.green(file + ' is converted!'));
+import('cwebp-bin').then(({ default: cwebp }) => {
+    fileList.forEach(function (file) {
+        execFile(cwebp, [file, '-o', file.replace(queryExtName(file),".webp")], function (err) {
+            if (err) {
+                throw err;
+            }
+            console.log(chalk.green(file + ' is converted!'));
+        });
     });
-})
+});

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "commander": "^2.9.0",
-    "cwebp-bin": "^3.2.0",
-    "image-type": "^2.1.0",
+    "cwebp-bin": "^7.0.1",
+    "image-type": "^4.1.0",
     "read-chunk": "^2.0.0"
   }
 }


### PR DESCRIPTION
Upgrade packages `cwebp-bin` and `image-type`. The number of vulnerabilities output by `npm audit` went from 17 (4 low, 2 moderate, 8 high, 3 critical) to 1 moderate severity vulnerability.

`cwebp-bin` uses native ES Modules since version 7.0.0 so I had to update index.js to load it using dynamic import().

Please let me know if there's anything I should change!